### PR TITLE
Allow for absence of managed identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ install-config.yaml
 extras.tf
 vnet/nat-gateway.tf
 bastion.tf
+**/az/*

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ azure_storage_account_name        = "XXXX"
 | azure_role_id_cluster | If needed, provide the ID of the Azure Custom Role scoped for the main Cluster Resource Group | `null` | string
 | azure_role_id_network | If needed, provide the ID of the Azure Custom Role scoped for the network Resource Group | `null` | string
 | use_default_imageregistry | Define if you want to use the default imageregistry that is created with the install | `true` | bool
+| openshift_managed_infrastructure | Define if the infrastructure is managed by openshift (IPI) | `true` | bool
+| azure_worker_root_volume_type | The type of the volume the root block device of worker nodes | Premium_LRS | string
 
 
 

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -1,8 +1,8 @@
 locals {
   bootstrap_nic_ip_v4_configuration_name = "bootstrap-nic-ip-v4"
   bootstrap_nic_ip_v6_configuration_name = "bootstrap-nic-ip-v6"
+  identity_list = var.managed_infrastructure ? [var.identity] : []
 }
-
 
 resource "azurerm_public_ip" "bootstrap_public_ip_v4" {
   count = var.private || ! var.use_ipv4 ? 0 : 1
@@ -131,9 +131,12 @@ resource "azurerm_linux_virtual_machine" "bootstrap" {
   admin_password                  = "NotActuallyApplied!"
   disable_password_authentication = false
 
-  identity {
-    type         = "UserAssigned"
-    identity_ids = [var.identity]
+  dynamic "identity" {
+    for_each = local.identity_list
+    content {
+      type         = "UserAssigned"
+      identity_ids = local.identity_list
+    }
   }
 
   os_disk {

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -118,3 +118,9 @@ variable "phase1_complete" {
   type        = bool
   default     = false  
 }
+
+variable "managed_infrastructure" {
+  description = "Define if nodes are is managed by openshift"
+  type        = bool
+  default     = true  
+}

--- a/ignition/ignition.tf
+++ b/ignition/ignition.tf
@@ -100,6 +100,7 @@ resource "null_resource" "generate_ignition" {
     local_file.cluster-infrastructure-02-config,
     local_file.cluster-dns-02-config,
     local_file.cloud-provider-config,
+    local_file.cluster-ingress-default-ingresscontroller,
     local_file.openshift-cluster-api_master-machines,
     local_file.openshift-cluster-api_worker-machineset,
     local_file.openshift-cluster-api_infra-machineset,

--- a/ignition/output.tf
+++ b/ignition/output.tf
@@ -5,3 +5,7 @@ output "bootstrap_ignition" {
 output "master_ignition" {
   value = data.ignition_config.master_redirect.rendered
 }
+
+output "worker_ignition" {
+  value = data.ignition_config.worker_redirect.rendered
+}

--- a/ignition/scripts/manifests.sh.tmpl
+++ b/ignition/scripts/manifests.sh.tmpl
@@ -3,3 +3,4 @@
 ${installer_workspace}/openshift-install --dir=${installer_workspace} create manifests --log-level=debug
 rm ${installer_workspace}/openshift/99_openshift-cluster-api_worker-machineset-*
 rm ${installer_workspace}/openshift/99_openshift-cluster-api_master-machines-*
+rm ${installer_workspace}/manifests/cluster-ingress-default-ingresscontroller.yaml

--- a/ignition/variables.tf
+++ b/ignition/variables.tf
@@ -185,3 +185,9 @@ variable "apps_ip" {
   type    = string
   default = ""
 }
+
+variable "managed_infrastructure" {
+  description = "Define if nodes are managed by openshift"
+  type        = bool
+  default     = true  
+}

--- a/variables-azure.tf
+++ b/variables-azure.tf
@@ -383,3 +383,15 @@ variable "use_default_imageregistry" {
   default     = true
 }
 
+variable "openshift_managed_infrastructure" {
+  description = "Define if the infrastructure is managed by openshift"
+  type        = bool
+  default     = true  
+}
+
+variable "azure_worker_root_volume_type" {
+  type        = string
+  description = "The type of the volume the root block device of worker nodes."
+  default     = "Premium_LRS"
+}
+

--- a/vnet/common.tf
+++ b/vnet/common.tf
@@ -26,11 +26,11 @@ data "azurerm_virtual_network" "preexisting_virtual_network" {
 
 // Only reference data sources which are guaranteed to exist at any time (above) in this locals{} block
 locals {
-  master_subnet_cidr_v4 = var.use_ipv4 ? cidrsubnet(var.vnet_v4_cidrs[0], 3, 0) : null  #master subnet is a smaller subnet within the vnet. i.e from /21 to /24
-  master_subnet_cidr_v6 = var.use_ipv6 ? cidrsubnet(var.vnet_v6_cidrs[0], 16, 0) : null #master subnet is a smaller subnet within the vnet. i.e from /48 to /64
+  master_subnet_cidr_v4 = var.use_ipv4 ? cidrsubnet(var.vnet_v4_cidrs[0], 8, 1) : null  #master subnet is a smaller subnet within the vnet. i.e from /21 to /24
+  master_subnet_cidr_v6 = var.use_ipv6 ? cidrsubnet(var.vnet_v6_cidrs[0], 16, 1) : null #master subnet is a smaller subnet within the vnet. i.e from /48 to /64
 
-  worker_subnet_cidr_v4 = var.use_ipv4 ? cidrsubnet(var.vnet_v4_cidrs[0], 3, 1) : null  #node subnet is a smaller subnet within the vnet. i.e from /21 to /24
-  worker_subnet_cidr_v6 = var.use_ipv6 ? cidrsubnet(var.vnet_v6_cidrs[0], 16, 1) : null #node subnet is a smaller subnet within the vnet. i.e from /48 to /64
+  worker_subnet_cidr_v4 = var.use_ipv4 ? cidrsubnet(var.vnet_v4_cidrs[0], 8, 2) : null  #node subnet is a smaller subnet within the vnet. i.e from /21 to /24
+  worker_subnet_cidr_v6 = var.use_ipv6 ? cidrsubnet(var.vnet_v6_cidrs[0], 16, 2) : null #node subnet is a smaller subnet within the vnet. i.e from /48 to /64
 
   master_subnet_id = var.preexisting_network ? data.azurerm_subnet.preexisting_master_subnet[0].id : azurerm_subnet.master_subnet[0].id
   worker_subnet_id = var.preexisting_network ? data.azurerm_subnet.preexisting_worker_subnet[0].id : azurerm_subnet.worker_subnet[0].id

--- a/vnet/internal-lb.tf
+++ b/vnet/internal-lb.tf
@@ -1,6 +1,8 @@
 locals {
   internal_lb_frontend_ip_v4_configuration_name = "internal-lb-ip-v4"
   internal_lb_frontend_ip_v6_configuration_name = "internal-lb-ip-v6"
+  internal_lb_apps_frontend_ip_v4_configuration_name = "internal-lb-apps-ip-v4"
+  internal_lb_apps_frontend_ip_v6_configuration_name = "internal-lb-apps-ip-v6"
 }
 
 resource "azurerm_lb" "internal" {
@@ -30,6 +32,30 @@ resource "azurerm_lb" "internal" {
       #   were being assigned the same IP dynamically). Issue is being tracked as a support ticket to Azure.
       private_ip_address_allocation = frontend_ip_configuration.value.ipv6 || var.dns_api_ip != ""  ? "Static" : "Dynamic"
       private_ip_address            = frontend_ip_configuration.value.ipv6 ? cidrhost(local.master_subnet_cidr_v6, -2) : var.dns_api_ip
+    }
+  }
+
+  dynamic "frontend_ip_configuration" {
+    for_each = [for ip in [
+      // TODO: internal LB should block v4 for better single stack emulation (&& ! var.emulate_single_stack_ipv6)
+      //   but RHCoS initramfs can't do v6 and so fails to ignite. https://issues.redhat.com/browse/GRPA-1343 
+      { name : local.internal_lb_apps_frontend_ip_v4_configuration_name, ipv6 : false, include : var.use_ipv4 },
+      { name : local.internal_lb_apps_frontend_ip_v6_configuration_name, ipv6 : true, include : var.use_ipv6 },
+      ] : {
+      name : ip.name
+      ipv6 : ip.ipv6
+      include : ip.include
+      } if ip.include
+    ]
+
+    content {
+      name                       = frontend_ip_configuration.value.name
+      subnet_id                  = local.worker_subnet_id
+      private_ip_address_version = frontend_ip_configuration.value.ipv6 ? "IPv6" : "IPv4"
+      # WORKAROUND: Allocate a high ipv6 internal LB address to avoid the race with NIC allocation (a master and the LB
+      #   were being assigned the same IP dynamically). Issue is being tracked as a support ticket to Azure.
+      private_ip_address_allocation = frontend_ip_configuration.value.ipv6 || var.dns_apps_ip != ""  ? "Static" : "Dynamic"
+      private_ip_address            = frontend_ip_configuration.value.ipv6 ? cidrhost(local.worker_subnet_cidr_v6, -2) : var.dns_apps_ip
     }
   }
 }
@@ -138,4 +164,98 @@ resource "azurerm_lb_probe" "internal_lb_probe_api_internal" {
   port                = 6443
   protocol            = "HTTPS"
   request_path        = "/readyz"
+}
+
+resource "azurerm_lb_backend_address_pool" "internal_lb_worker_pool_v4" {
+  count = var.use_ipv4 ? 1 : 0
+
+  resource_group_name = var.resource_group_name
+  loadbalancer_id     = azurerm_lb.internal.id
+  name                = "${var.cluster_id}-apps"
+}
+
+resource "azurerm_lb_backend_address_pool" "internal_lb_worker_pool_v6" {
+  count = var.use_ipv6 ? 1 : 0
+
+  resource_group_name = var.resource_group_name
+  loadbalancer_id     = azurerm_lb.internal.id
+  name                = "${var.cluster_id}-apps-IPv6"
+}
+
+resource "azurerm_lb_probe" "internal_lb_probe_http" {
+  name                = "apps-http-probe"
+  resource_group_name = var.resource_group_name
+  interval_in_seconds = 10
+  number_of_probes    = 3
+  loadbalancer_id     = azurerm_lb.internal.id
+  port                = 80
+  protocol            = "TCP"
+}
+
+resource "azurerm_lb_rule" "internal_lb_rule_apps_http_v4" {
+  count = var.use_ipv4 ? 1 : 0
+
+  name                           = "apps-http-internal-v4"
+  resource_group_name            = var.resource_group_name
+  protocol                       = "Tcp"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.internal_lb_worker_pool_v4[0].id
+  loadbalancer_id                = azurerm_lb.internal.id
+  frontend_port                  = 80
+  backend_port                   = 80
+  frontend_ip_configuration_name = local.internal_lb_apps_frontend_ip_v4_configuration_name
+  enable_floating_ip             = false
+  idle_timeout_in_minutes        = 30
+  load_distribution              = "Default"
+  probe_id                       = azurerm_lb_probe.internal_lb_probe_http.id
+}
+
+resource "azurerm_lb_rule" "internal_lb_rule_apps_http_v6" {
+  count = var.use_ipv6 ? 1 : 0
+
+  name                           = "apps-http-internal-v6"
+  resource_group_name            = var.resource_group_name
+  protocol                       = "Tcp"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.internal_lb_worker_pool_v6[0].id
+  loadbalancer_id                = azurerm_lb.internal.id
+  frontend_port                  = 80
+  backend_port                   = 80
+  frontend_ip_configuration_name = local.internal_lb_apps_frontend_ip_v6_configuration_name
+  enable_floating_ip             = false
+  idle_timeout_in_minutes        = 30
+  load_distribution              = "Default"
+  probe_id                       = azurerm_lb_probe.internal_lb_probe_http.id
+}
+
+resource "azurerm_lb_rule" "internal_lb_rule_apps_https_v4" {
+  count = var.use_ipv4 ? 1 : 0
+
+  name                           = "apps-https-internal-v4"
+  resource_group_name            = var.resource_group_name
+  protocol                       = "Tcp"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.internal_lb_worker_pool_v4[0].id
+  loadbalancer_id                = azurerm_lb.internal.id
+  frontend_port                  = 443
+  backend_port                   = 443
+  frontend_ip_configuration_name = local.internal_lb_apps_frontend_ip_v4_configuration_name
+  enable_floating_ip             = false
+  idle_timeout_in_minutes        = 30
+  load_distribution              = "Default"
+  probe_id                       = azurerm_lb_probe.internal_lb_probe_http.id
+}
+
+resource "azurerm_lb_rule" "internal_lb_rule_apps_https_v6" {
+  count = var.use_ipv6 ? 1 : 0
+
+  name                           = "apps-https-internal-v6"
+  resource_group_name            = var.resource_group_name
+  protocol                       = "Tcp"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.internal_lb_worker_pool_v6[0].id
+  loadbalancer_id                = azurerm_lb.internal.id
+  frontend_port                  = 443
+  backend_port                   = 443
+  frontend_ip_configuration_name = local.internal_lb_apps_frontend_ip_v6_configuration_name
+  enable_floating_ip             = false
+  idle_timeout_in_minutes        = 30
+  load_distribution              = "Default"
+  probe_id                       = azurerm_lb_probe.internal_lb_probe_http.id
 }

--- a/vnet/nsg.tf
+++ b/vnet/nsg.tf
@@ -31,3 +31,45 @@ resource "azurerm_network_security_rule" "apiserver_in" {
   resource_group_name         = var.resource_group_name
   network_security_group_name = azurerm_network_security_group.cluster.name
 }
+
+resource "azurerm_network_security_rule" "ssh_in" {
+  name                        = "ssh_in"
+  priority                    = 110
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.cluster.name
+}
+
+resource "azurerm_network_security_rule" "tcp-http" {
+  name                        = "tcp-80"
+  priority                    = 201
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "80"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.cluster.name
+}
+
+resource "azurerm_network_security_rule" "tcp-https" {
+  name                        = "tcp-443"
+  priority                    = 202
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "443"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.cluster.name
+}

--- a/vnet/outputs.tf
+++ b/vnet/outputs.tf
@@ -6,6 +6,14 @@ output "public_lb_backend_pool_v6_id" {
   value = local.need_public_ipv6 ? azurerm_lb_backend_address_pool.public_lb_pool_v6[0].id : null
 }
 
+output "internal_lb_apps_backend_pool_v4_id" {
+  value = var.use_ipv4 ? azurerm_lb_backend_address_pool.internal_lb_worker_pool_v4[0].id : null
+}
+
+output "internal_lb_apps_backend_pool_v6_id" {
+  value = var.use_ipv6 ? azurerm_lb_backend_address_pool.internal_lb_worker_pool_v6[0].id : null
+}
+
 output "internal_lb_backend_pool_v4_id" {
   value = var.use_ipv4 ? azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v4[0].id : null
 }

--- a/vnet/variables.tf
+++ b/vnet/variables.tf
@@ -91,3 +91,8 @@ variable "dns_api_ip" {
   type = string
   default = ""
 }
+
+variable "dns_apps_ip" {
+  type = string
+  default = ""
+}

--- a/worker/outputs.tf
+++ b/worker/outputs.tf
@@ -1,0 +1,3 @@
+output "ip_addresses" {
+  value = azurerm_network_interface.worker.*.private_ip_address
+}

--- a/worker/variables.tf
+++ b/worker/variables.tf
@@ -18,7 +18,7 @@ variable "vm_size" {
 
 variable "vm_image" {
   type        = string
-  description = "The resource id of the vm image used for masters."
+  description = "The resource id of the vm image used for workers."
 }
 
 variable "identity" {
@@ -46,7 +46,7 @@ variable "ilb_backend_pool_v6_id" {
   type = string
 }
 
-variable "ignition_master" {
+variable "ignition_worker" {
   type    = string
   default = ""
 }
@@ -58,7 +58,7 @@ variable "kubeconfig_content" {
 
 variable "subnet_id" {
   type        = string
-  description = "The subnet to attach the masters to."
+  description = "The subnet to attach the workers to."
 }
 
 variable "os_volume_type" {
@@ -88,7 +88,7 @@ variable "ignition" {
 
 variable "availability_zones" {
   type        = list(string)
-  description = "List of the availability zones in which to create the masters. The length of this list must match instance_count."
+  description = "List of the availability zones in which to create the workers. The length of this list must match instance_count."
 }
 
 variable "private" {

--- a/worker/versions.tf
+++ b/worker/versions.tf
@@ -1,0 +1,9 @@
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}

--- a/worker/worker.tf
+++ b/worker/worker.tf
@@ -1,16 +1,16 @@
 locals {
-  // The name of the masters' ipconfiguration is hardcoded to "pipconfig". It needs to match cluster-api
-  // https://github.com/openshift/cluster-api-provider-azure/blob/master/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go#L131
+  // The name of the workers' ipconfiguration is hardcoded to "pipconfig". It needs to match cluster-api
+  // https://github.com/openshift/cluster-api-provider-azure/blob/worker/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go#L131
   ip_v4_configuration_name = "pipConfig"
   // TODO: Azure machine provider probably needs to look for pipConfig-v6 as well (or a different name like pipConfig-secondary)
   ip_v6_configuration_name = "pipConfig-v6"
   identity_list = var.managed_infrastructure ? [var.identity] : []
 }
 
-resource "azurerm_network_interface" "master" {
+resource "azurerm_network_interface" "worker" {
   count = var.instance_count
 
-  name                = "${var.cluster_id}-master${count.index}-nic"
+  name                = "${var.cluster_id}-worker${count.index}-nic"
   location            = var.region
   resource_group_name = var.resource_group_name
 
@@ -46,54 +46,54 @@ resource "azurerm_network_interface" "master" {
   }
 }
 
-resource "azurerm_network_interface_backend_address_pool_association" "master_v4" {
+resource "azurerm_network_interface_backend_address_pool_association" "worker_v4" {
   // This is required because terraform cannot calculate counts during plan phase completely and therefore the `vnet/public-lb.tf`
   // conditional need to be recreated. See https://github.com/hashicorp/terraform/issues/12570
   count = (! var.private || ! var.outbound_udr) ? var.instance_count : 0
 
-  network_interface_id    = element(azurerm_network_interface.master.*.id, count.index)
+  network_interface_id    = element(azurerm_network_interface.worker.*.id, count.index)
   backend_address_pool_id = var.elb_backend_pool_v4_id
   ip_configuration_name   = local.ip_v4_configuration_name
 }
 
-resource "azurerm_network_interface_backend_address_pool_association" "master_v6" {
+resource "azurerm_network_interface_backend_address_pool_association" "worker_v6" {
   // This is required because terraform cannot calculate counts during plan phase completely and therefore the `vnet/public-lb.tf`
   // conditional need to be recreated. See https://github.com/hashicorp/terraform/issues/12570
   count = var.use_ipv6 && (! var.private || ! var.outbound_udr) ? var.instance_count : 0
 
-  network_interface_id    = element(azurerm_network_interface.master.*.id, count.index)
+  network_interface_id    = element(azurerm_network_interface.worker.*.id, count.index)
   backend_address_pool_id = var.elb_backend_pool_v6_id
   ip_configuration_name   = local.ip_v6_configuration_name
 }
 
-resource "azurerm_network_interface_backend_address_pool_association" "master_internal_v4" {
+resource "azurerm_network_interface_backend_address_pool_association" "worker_internal_v4" {
   count = var.use_ipv4 ? var.instance_count : 0
 
-  network_interface_id    = element(azurerm_network_interface.master.*.id, count.index)
+  network_interface_id    = element(azurerm_network_interface.worker.*.id, count.index)
   backend_address_pool_id = var.ilb_backend_pool_v4_id
   ip_configuration_name   = local.ip_v4_configuration_name
 }
 
-resource "azurerm_network_interface_backend_address_pool_association" "master_internal_v6" {
+resource "azurerm_network_interface_backend_address_pool_association" "worker_internal_v6" {
   count = var.use_ipv6 ? var.instance_count : 0
 
-  network_interface_id    = element(azurerm_network_interface.master.*.id, count.index)
+  network_interface_id    = element(azurerm_network_interface.worker.*.id, count.index)
   backend_address_pool_id = var.ilb_backend_pool_v6_id
   ip_configuration_name   = local.ip_v6_configuration_name
 }
 
-resource "azurerm_linux_virtual_machine" "master" {
+resource "azurerm_linux_virtual_machine" "worker" {
   count = !var.phased_approach || (var.phased_approach && var.phase1_complete) ? var.instance_count : 0 
 
   depends_on = [
-    azurerm_network_interface.master
+    azurerm_network_interface.worker
   ]
   
-  name                  = "${var.cluster_id}-master-${count.index}"
+  name                  = "${var.cluster_id}-worker-${count.index}"
   location              = var.region
-  zone                  = length(var.availability_zones) > 1 ? var.availability_zones[count.index] : var.availability_zones[0]
+  zone                  = length(var.availability_zones) > 1 ? var.availability_zones[count.index % length(var.availability_zones)] : var.availability_zones[0]
   resource_group_name   = var.resource_group_name
-  network_interface_ids = [element(azurerm_network_interface.master.*.id, count.index)]
+  network_interface_ids = [element(azurerm_network_interface.worker.*.id, count.index)]
   size                  = var.vm_size
   admin_username        = "core"
   # The password is normally applied by WALA (the Azure agent), but this
@@ -111,7 +111,7 @@ resource "azurerm_linux_virtual_machine" "master" {
   }
 
   os_disk {
-    name                 = "${var.cluster_id}-master-${count.index}_OSDisk" # os disk name needs to match cluster-api convention
+    name                 = "${var.cluster_id}-worker-${count.index}_OSDisk" # os disk name needs to match cluster-api convention
     caching              = "ReadOnly"
     storage_account_type = var.os_volume_type
     disk_size_gb         = var.os_volume_size
@@ -121,7 +121,7 @@ resource "azurerm_linux_virtual_machine" "master" {
 
   //we don't provide a ssh key, because it is set with ignition. 
   //it is required to provide at least 1 auth method to deploy a linux vm
-  computer_name = "${var.cluster_id}-master-${count.index}"
+  computer_name = "${var.cluster_id}-worker-${count.index}"
   custom_data   = base64encode(var.ignition)
 
   boot_diagnostics {


### PR DESCRIPTION
Add openshift_managed_infrastructure to indicate when openshift is integrated with Azure via a managed identity.  Set to false when Azure infrastructure is fully managed external to OpenShift.

